### PR TITLE
Death to dying mcstats

### DIFF
--- a/plugins/PluginMetrics/config.yml
+++ b/plugins/PluginMetrics/config.yml
@@ -1,4 +1,4 @@
 # http://mcstats.org
-opt-out: false
+opt-out: true
 guid: 52ee4243-9986-46d2-8176-0181dc425bd3
 debug: false


### PR DESCRIPTION
So it doesn't gunk up server logs, if we care about those... do we? (If we don't, .gitignore needs .gz too)
