### PR TITLE
Get rid of explosions?

### DIFF
--- a/plugins/PermissionsEx/config.yml
+++ b/plugins/PermissionsEx/config.yml
@@ -14,5 +14,5 @@ permissions:
     file:
       type: file
       file: permissions.yml
-updater: true
+updater: false
 alwaysUpdate: false

--- a/plugins/WorldGuard/config.yml
+++ b/plugins/WorldGuard/config.yml
@@ -82,24 +82,24 @@ physics:
     allow-portal-anywhere: false
     disable-water-damage-blocks: []
 ignition:
-    block-tnt: false
+    block-tnt: true
     block-tnt-block-damage: false
-    block-lighter: false
+    block-lighter: true
 fire:
     disable-lava-fire-spread: true
-    disable-all-fire-spread: false
+    disable-all-fire-spread: true
     disable-fire-spread-blocks: []
     lava-spread-blocks: []
 mobs:
-    block-creeper-explosions: false
+    block-creeper-explosions: true
     block-creeper-block-damage: false
-    block-wither-explosions: false
+    block-wither-explosions: true
     block-wither-block-damage: false
     block-wither-skull-explosions: false
     block-wither-skull-block-damage: false
     block-enderdragon-block-damage: false
     block-enderdragon-portal-creation: false
-    block-fireball-explosions: false
+    block-fireball-explosions: true
     block-fireball-block-damage: false
     anti-wolf-dumbness: false
     allow-tamed-spawns: true
@@ -109,7 +109,7 @@ mobs:
     block-item-frame-destroy: false
     block-plugin-spawning: true
     block-above-ground-slimes: false
-    block-other-explosions: false
+    block-other-explosions: true
     block-zombie-door-destruction: false
     block-creature-spawn: []
 player-damage:


### PR DESCRIPTION
Uses worldguard's event handling to get rid of mob , tnt, & fireball explosions. Not that we're going to use those are we? Damage from mobs and tnt will still be felt though.
