### PR TITLE
Add ability to actually claim a plot

### DIFF
--- a/plugins/PermissionsEx/permissions.yml
+++ b/plugins/PermissionsEx/permissions.yml
@@ -11,6 +11,7 @@ groups:
     - essentials.msg
     - essentials.reply
     - plots.permpack.basic
+    - plots.plot.1
     options:
       build: false
       rank: '1000'
@@ -18,6 +19,7 @@ groups:
       default: true
   Builder:
     permissions:
+    - plots.plot.4
     - essentials.afk
     - essentials.back
     - essentials.back.ondeath


### PR DESCRIPTION
Should everyone only claim 1 or 4 plots, or everyone can get 1 and builders can get 4 (as this PR is currently configured)?

Note that those who can claim at least more than 1 will be able to merge plots as well (if they're contiguous).
