### PR TITLE
Disable NCP survivalfly

### DIFF
--- a/plugins/NoCheatPlus/config.yml
+++ b/plugins/NoCheatPlus/config.yml
@@ -401,7 +401,7 @@ checks:
           - set back
           - back set
     survivalfly:
-      active: true
+      active: false
       extended:
         vertical-accounting: true
       falldamage: true

--- a/plugins/NoCheatPlus/config.yml
+++ b/plugins/NoCheatPlus/config.yml
@@ -351,7 +351,7 @@ checks:
       ignorecreative: false
       model:
         creative:
-          horizontalspeed: 100
+          horizontalspeed: 150
           verticalspeed: 100
           maxheight: 128
         spectator:


### PR DESCRIPTION
Considering the new Elytra thingy, this (amongst probably some other checks) might need to be disabled. My guess is that there are not many hack clients made for snapshot versions... hopefully?

Otherwise we could simply give certain users survivalfly permission bypasses when they get an Elytra or something.

(I haven't played any snapshot versions yet so I'm totally guessing.)
