### PR TITLE
Disable "use-player-move-event" in WG

### DIFF
--- a/plugins/WorldGuard/config.yml
+++ b/plugins/WorldGuard/config.yml
@@ -44,7 +44,7 @@ regions:
 auto-invincible: false
 auto-invincible-group: false
 auto-no-drowning-group: false
-use-player-move-event: true
+use-player-move-event: false
 use-player-teleports: true
 security:
     deop-everyone-on-join: false


### PR DESCRIPTION
Disable the use of the PlayerMoveEvent in WorldGuard because of known performance issues.
