### PR TITLE
Fixes creative plots

### DIFF
--- a/plugins/GriefPreventionData/config.yml
+++ b/plugins/GriefPreventionData/config.yml
@@ -7,7 +7,7 @@ GriefPrevention:
     creative: -1
   Claims:
     Mode:
-      creative: Disabled
+      plots: Disabled
       world_nether: Disabled
       world_the_end: Disabled
       world: Survival

--- a/plugins/GriefPreventionData/config.yml
+++ b/plugins/GriefPreventionData/config.yml
@@ -7,7 +7,7 @@ GriefPrevention:
     creative: -1
   Claims:
     Mode:
-      creative: Creative
+      creative: Disabled
       world_nether: Disabled
       world_the_end: Disabled
       world: Survival


### PR DESCRIPTION
If a world in Grief Prevention is set to "Creative" it requires you to claim it before you can build.
Just set it to disabled to fix that.