### PR TITLE
Correct a typo in AutoMessage's config.yml

### DIFF
--- a/plugins/AutoMessage/config.yml
+++ b/plugins/AutoMessage/config.yml
@@ -29,5 +29,5 @@ message-lists:
       https://github.com/SpigotMC/SpigotCraft'
     - '&3[AutoMessage]&r Helpers may use /promote to promote users if they have given
       their name in the forum thread'
-    - '&3[AutoMessage]&r The aim of this excercise is to find release-critical 1.12
+    - '&3[AutoMessage]&r The aim of this exercise is to find release-critical 1.12
       bugs'


### PR DESCRIPTION
Hey,

I noticed a typo in automessage's configuration file. The word 'exercise' was misspelled, so I decided to make this extremely tiny and quick pull request.