### PR TITLE
Allow helpers to logblock lookup

### DIFF
--- a/plugins/PermissionsEx/permissions.yml
+++ b/plugins/PermissionsEx/permissions.yml
@@ -114,6 +114,8 @@ groups:
     - permissions.user.rank.demote
     - permissions.user.rank.promote
     - logblock.lookup
+    - logblock.tools.tool
+    - logblock.tools.toolblock
     inheritance:
     - Tester
     options:
@@ -167,8 +169,6 @@ groups:
     - essentials.world
     - essentials.worlds.*
     - logblock.spawnTools
-    - logblock.tools.tool
-    - logblock.tools.toolblock
     - permissions.manage.membership
     inheritance:
     - Helper

--- a/plugins/PermissionsEx/permissions.yml
+++ b/plugins/PermissionsEx/permissions.yml
@@ -113,6 +113,7 @@ groups:
     - permissions.user.promote.default
     - permissions.user.rank.demote
     - permissions.user.rank.promote
+    - logblock.lookup
     inheritance:
     - Tester
     options:
@@ -165,7 +166,6 @@ groups:
     - essentials.whois
     - essentials.world
     - essentials.worlds.*
-    - logblock.lookup
     - logblock.spawnTools
     - logblock.tools.tool
     - logblock.tools.toolblock


### PR DESCRIPTION
This makes it easier for grief reports.