### PR TITLE
Add 'minecraft:mushroom_stem' to Veinminer config.

### DIFF
--- a/plugins/VeinMiner/config.yml
+++ b/plugins/VeinMiner/config.yml
@@ -79,6 +79,7 @@ BlockList:
     - 'minecraft:carved_pumpkin'
     - 'minecraft:red_mushroom_block'
     - 'minecraft:brown_mushroom_block'
+    - 'minecraft:mushroom_stem'
   Shovel:
     - 'minecraft:sand'
     - 'minecraft:gravel'


### PR DESCRIPTION
Would make sense to be able to vein mine all Mushroom blocks instead of just the Brown and Red ones.

Perhaps not necessary but might serve as a QOL change. 